### PR TITLE
Cicd 46 add code formatter and ci/cd linter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -7,12 +7,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
-
-    - run: git checkout HEAD^2
+    - name: Check out the repo
+      uses: actions/checkout@v2
 
     - name: Run Linter
       run: |

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,6 @@
         "phpunit/phpunit": "^9.3",
         "vimeo/psalm": "4.13.1",
         "phpstan/phpstan": "^1.12",
-        "laravel/pint": "1.2.*"
+        "laravel/pint": "^1.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "minimum-stability": "stable",
     "scripts": {
         "check": "./vendor/bin/phpstan analyse --level max src tests",
-        "lint": "./vendor/bin/pint --test",
-        "format": "./vendor/bin/pint"
+        "lint": "./vendor/bin/pint --test --config pint.json",
+        "format": "./vendor/bin/pint --config pint.json"
     },
     "autoload": {
         "psr-4": {"Utopia\\Cache\\": "src/Cache"}

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,6 @@
+{
+    "preset": "psr12",
+    "exclude": [
+        "tests/resources"
+    ]
+}


### PR DESCRIPTION
1. Installed and configured Laravel Pint to settings of [open-runtimes/executor](https://github.com/open-runtimes/executor).
2. Add commands to run formatting and linting according to Pint configuration.
3. Modified linter.yml to match linter.yml of [open-runtimes/executor](https://github.com/open-runtimes/executor).